### PR TITLE
Refactor admin features to use services

### DIFF
--- a/src/components/Admin/AdminDashboard.tsx
+++ b/src/components/Admin/AdminDashboard.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
-import { supabase } from '@/integrations/supabase/client';
+import { useServices } from '@/providers/ServiceProvider';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { MessageSquare, Users, Phone, FileText } from 'lucide-react';
 import { useLoadingSpinner } from '@/hooks/useLoadingSpinner';
@@ -27,6 +27,8 @@ const AdminDashboard = () => {
     fullScreen: false
   });
 
+  const { statisticsService } = useServices();
+
   useEffect(() => {
     fetchStats();
   }, []);
@@ -34,19 +36,8 @@ const AdminDashboard = () => {
   const fetchStats = async () => {
     startLoading();
     try {
-      const [reviewsRes, partnersRes, contactsRes, contentRes] = await Promise.all([
-        supabase.from('reviews').select('id', { count: 'exact', head: true }),
-        supabase.from('partners_logos').select('id', { count: 'exact', head: true }),
-        supabase.from('contact_info').select('id', { count: 'exact', head: true }),
-        supabase.from('content_sections').select('id', { count: 'exact', head: true }),
-      ]);
-
-      setStats({
-        reviews: reviewsRes.count || 0,
-        partners: partnersRes.count || 0,
-        contacts: contactsRes.count || 0,
-        content: contentRes.count || 0,
-      });
+      const result = await statisticsService.getAdminStats();
+      setStats(result);
     } catch (error) {
       console.error('Erreur lors du chargement des statistiques:', error);
     } finally {

--- a/src/components/Admin/ContactInfoForm.tsx
+++ b/src/components/Admin/ContactInfoForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { supabase } from '@/integrations/supabase/client';
+import { useRepositories } from '@/hooks/useRepositories';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -53,6 +53,8 @@ const ContactInfoForm = ({ contact, onSuccess, onCancel }: ContactInfoFormProps)
     }
   }, [contact]);
 
+  const { contactRepository } = useRepositories();
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
@@ -65,30 +67,18 @@ const ContactInfoForm = ({ contact, onSuccess, onCancel }: ContactInfoFormProps)
 
     try {
       if (contact) {
-        // Mise à jour
-        const { error } = await supabase
-          .from('contact_info')
-          .update({
-            type: formData.type.trim(),
-            value: formData.value.trim(),
-            label: formData.label.trim() || null,
-            updated_at: new Date().toISOString(),
-          })
-          .eq('id', contact.id);
-
-        if (error) throw error;
+        await contactRepository.updateContactInfo(contact.id, {
+          type: formData.type.trim(),
+          value: formData.value.trim(),
+          label: formData.label.trim() || null,
+        });
         showSuccess("Succès", "Information de contact mise à jour");
       } else {
-        // Création
-        const { error } = await supabase
-          .from('contact_info')
-          .insert({
-            type: formData.type.trim(),
-            value: formData.value.trim(),
-            label: formData.label.trim() || null,
-          });
-
-        if (error) throw error;
+        await contactRepository.createContactInfo({
+          type: formData.type.trim(),
+          value: formData.value.trim(),
+          label: formData.label.trim() || undefined,
+        });
         showSuccess("Succès", "Information de contact créée");
       }
 

--- a/src/components/Admin/DataBackup.tsx
+++ b/src/components/Admin/DataBackup.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
-import { supabase } from '@/integrations/supabase/client';
+import { useRepositories } from '@/hooks/useRepositories';
 import { Download, Upload, Database, Calendar, FileText, Shield } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
@@ -40,6 +40,12 @@ const DataBackup = () => {
   const [isCreatingBackup, setIsCreatingBackup] = useState(false);
   const [backupProgress, setBackupProgress] = useState(0);
   const { toast } = useToast();
+  const {
+    reviewRepository,
+    contactRepository,
+    contentRepository,
+    partnerRepository
+  } = useRepositories();
 
   const createBackup = async () => {
     setIsCreatingBackup(true);
@@ -51,34 +57,22 @@ const DataBackup = () => {
       
       // Reviews
       setBackupProgress(25);
-      const { data: reviewsData, error: reviewsError } = await supabase
-        .from('reviews')
-        .select('*');
-      if (reviewsError) throw reviewsError;
+      const reviewsData = await reviewRepository.getAllReviews();
       data.reviews = reviewsData;
       
       // Contact info
       setBackupProgress(50);
-      const { data: contactData, error: contactError } = await supabase
-        .from('contact_info')
-        .select('*');
-      if (contactError) throw contactError;
+      const contactData = await contactRepository.getAllContactInfo();
       data.contact_info = contactData;
       
       // Content sections
       setBackupProgress(75);
-      const { data: contentData, error: contentError } = await supabase
-        .from('content_sections')
-        .select('*');
-      if (contentError) throw contentError;
+      const contentData = await contentRepository.getAllContentSections();
       data.content_sections = contentData;
       
       // Partners logos
       setBackupProgress(100);
-      const { data: partnersData, error: partnersError } = await supabase
-        .from('partners_logos')
-        .select('*');
-      if (partnersError) throw partnersError;
+      const partnersData = await partnerRepository.getAllPartners();
       data.partners_logos = partnersData;
       
       // Création du fichier de sauvegarde
@@ -168,38 +162,22 @@ const DataBackup = () => {
   const exportTable = async (tableName: 'reviews' | 'contact_info' | 'content_sections' | 'partners_logos') => {
     try {
       let data: any[] = [];
-      
+
       switch (tableName) {
         case 'reviews':
-          const { data: reviewsData, error: reviewsError } = await supabase
-            .from('reviews')
-            .select('*');
-          if (reviewsError) throw reviewsError;
-          data = reviewsData || [];
+          data = await reviewRepository.getAllReviews();
           break;
-          
+
         case 'contact_info':
-          const { data: contactData, error: contactError } = await supabase
-            .from('contact_info')
-            .select('*');
-          if (contactError) throw contactError;
-          data = contactData || [];
+          data = await contactRepository.getAllContactInfo();
           break;
-          
+
         case 'content_sections':
-          const { data: contentData, error: contentError } = await supabase
-            .from('content_sections')
-            .select('*');
-          if (contentError) throw contentError;
-          data = contentData || [];
+          data = await contentRepository.getAllContentSections();
           break;
-          
+
         case 'partners_logos':
-          const { data: partnersData, error: partnersError } = await supabase
-            .from('partners_logos')
-            .select('*');
-          if (partnersError) throw partnersError;
-          data = partnersData || [];
+          data = await partnerRepository.getAllPartners();
           break;
       }
       

--- a/src/interfaces/IPartnerService.ts
+++ b/src/interfaces/IPartnerService.ts
@@ -1,0 +1,8 @@
+import { CreatePartnerData, Partner, UpdatePartnerData } from './repositories/IPartnerRepository';
+
+export interface IPartnerService {
+  uploadPartnerLogo(file: File): Promise<string>;
+  getNextDisplayOrder(): Promise<number>;
+  createPartner(data: CreatePartnerData): Promise<Partner>;
+  updatePartner(id: string, data: UpdatePartnerData): Promise<Partner>;
+}

--- a/src/interfaces/IStatisticsService.ts
+++ b/src/interfaces/IStatisticsService.ts
@@ -1,0 +1,11 @@
+export interface AdminStats {
+  reviews: number;
+  partners: number;
+  contacts: number;
+  content: number;
+}
+
+export interface IStatisticsService {
+  getAdminStats(): Promise<AdminStats>;
+}
+

--- a/src/interfaces/repositories/IPartnerRepository.ts
+++ b/src/interfaces/repositories/IPartnerRepository.ts
@@ -31,4 +31,5 @@ export interface IPartnerRepository {
   updatePartner(id: string, data: UpdatePartnerData): Promise<Partner>;
   deletePartner(id: string): Promise<void>;
   updatePartnerOrder(partnerId: string, newOrder: number): Promise<void>;
+  getMaxDisplayOrder(): Promise<number>;
 }

--- a/src/providers/ServiceProvider.tsx
+++ b/src/providers/ServiceProvider.tsx
@@ -8,6 +8,8 @@ import { IContactRepository } from '@/interfaces/repositories/IContactRepository
 import { IReviewRepository } from '@/interfaces/repositories/IReviewRepository';
 import { IContentRepository } from '@/interfaces/repositories/IContentRepository';
 import { IPartnerRepository } from '@/interfaces/repositories/IPartnerRepository';
+import { IStatisticsService } from '@/interfaces/IStatisticsService';
+import { IPartnerService } from '@/interfaces/IPartnerService';
 import { AuthService } from '@/services/AuthService';
 import { AdminService } from '@/services/AdminService';
 import { securityMonitor } from '@/utils/securityMonitoring';
@@ -16,6 +18,8 @@ import { SupabaseContactRepository } from '@/repositories/SupabaseContactReposit
 import { SupabaseReviewRepository } from '@/repositories/SupabaseReviewRepository';
 import { SupabaseContentRepository } from '@/repositories/SupabaseContentRepository';
 import { SupabasePartnerRepository } from '@/repositories/SupabasePartnerRepository';
+import { statisticsService } from '@/services/StatisticsService';
+import { PartnerService } from '@/services/PartnerService';
 import type { Database } from '@/integrations/supabase/types';
 
 interface ServiceContextType {
@@ -28,6 +32,8 @@ interface ServiceContextType {
   reviewRepository: IReviewRepository;
   contentRepository: IContentRepository;
   partnerRepository: IPartnerRepository;
+  statisticsService: IStatisticsService;
+  partnerService: IPartnerService;
 }
 
 const ServiceContext = createContext<ServiceContextType | undefined>(undefined);
@@ -39,6 +45,8 @@ interface ServiceProviderProps {
   reviewRepository?: IReviewRepository;
   contentRepository?: IContentRepository;
   partnerRepository?: IPartnerRepository;
+  statisticsService?: IStatisticsService;
+  partnerService?: IPartnerService;
 }
 
 // Wrapper pour Supabase client
@@ -59,10 +67,12 @@ export const ServiceProvider: React.FC<ServiceProviderProps> = ({
   contactRepository,
   reviewRepository,
   contentRepository,
-  partnerRepository
+  partnerRepository,
+  statisticsService: injectedStatisticsService,
+  partnerService: injectedPartnerService
 }) => {
   const supabaseClient = new SupabaseClientWrapper();
-  
+
   const services: ServiceContextType = {
     authService: AuthService,
     adminService: AdminService,
@@ -73,6 +83,8 @@ export const ServiceProvider: React.FC<ServiceProviderProps> = ({
     reviewRepository: reviewRepository || new SupabaseReviewRepository(),
     contentRepository: contentRepository || new SupabaseContentRepository(),
     partnerRepository: partnerRepository || new SupabasePartnerRepository(),
+    statisticsService: injectedStatisticsService || statisticsService,
+    partnerService: injectedPartnerService || new PartnerService(partnerRepository || new SupabasePartnerRepository()),
   };
 
   return (

--- a/src/repositories/SupabasePartnerRepository.ts
+++ b/src/repositories/SupabasePartnerRepository.ts
@@ -75,4 +75,15 @@ export class SupabasePartnerRepository implements IPartnerRepository {
 
     if (error) throw error;
   }
+
+  async getMaxDisplayOrder(): Promise<number> {
+    const { data, error } = await supabase
+      .from('partners_logos')
+      .select('display_order')
+      .order('display_order', { ascending: false })
+      .limit(1);
+
+    if (error) throw error;
+    return data?.[0]?.display_order ?? 0;
+  }
 }

--- a/src/services/PartnerService.ts
+++ b/src/services/PartnerService.ts
@@ -1,0 +1,38 @@
+import { supabase } from '@/integrations/supabase/client';
+import { IPartnerService } from '@/interfaces/IPartnerService';
+import {
+  IPartnerRepository,
+  CreatePartnerData,
+  UpdatePartnerData,
+  Partner
+} from '@/interfaces/repositories/IPartnerRepository';
+
+export class PartnerService implements IPartnerService {
+  constructor(private repository: IPartnerRepository) {}
+
+  async uploadPartnerLogo(file: File): Promise<string> {
+    const ext = file.name.split('.').pop();
+    const fileName = `partners/${Date.now()}.${ext}`;
+    const { error } = await supabase.storage
+      .from('partners-logos')
+      .upload(fileName, file);
+    if (error) throw error;
+    const { data: { publicUrl } } = supabase.storage
+      .from('partners-logos')
+      .getPublicUrl(fileName);
+    return publicUrl;
+  }
+
+  async getNextDisplayOrder(): Promise<number> {
+    const max = await this.repository.getMaxDisplayOrder();
+    return max + 1;
+  }
+
+  async createPartner(data: CreatePartnerData): Promise<Partner> {
+    return this.repository.createPartner(data);
+  }
+
+  async updatePartner(id: string, data: UpdatePartnerData): Promise<Partner> {
+    return this.repository.updatePartner(id, data);
+  }
+}

--- a/src/services/StatisticsService.ts
+++ b/src/services/StatisticsService.ts
@@ -1,0 +1,27 @@
+import { supabase } from '@/integrations/supabase/client';
+import { AdminStats, IStatisticsService } from '@/interfaces/IStatisticsService';
+
+export class SupabaseStatisticsService implements IStatisticsService {
+  async getAdminStats(): Promise<AdminStats> {
+    const [reviewsRes, partnersRes, contactsRes, contentRes] = await Promise.all([
+      supabase.from('reviews').select('id', { count: 'exact', head: true }),
+      supabase.from('partners_logos').select('id', { count: 'exact', head: true }),
+      supabase.from('contact_info').select('id', { count: 'exact', head: true }),
+      supabase.from('content_sections').select('id', { count: 'exact', head: true })
+    ]);
+
+    if (reviewsRes.error) throw reviewsRes.error;
+    if (partnersRes.error) throw partnersRes.error;
+    if (contactsRes.error) throw contactsRes.error;
+    if (contentRes.error) throw contentRes.error;
+
+    return {
+      reviews: reviewsRes.count || 0,
+      partners: partnersRes.count || 0,
+      contacts: contactsRes.count || 0,
+      content: contentRes.count || 0
+    };
+  }
+}
+
+export const statisticsService = new SupabaseStatisticsService();

--- a/src/services/__tests__/PartnerService.test.ts
+++ b/src/services/__tests__/PartnerService.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PartnerService } from '@/services/PartnerService';
+import { supabase } from '@/integrations/supabase/client';
+import { IPartnerRepository } from '@/interfaces/repositories/IPartnerRepository';
+
+vi.mock('@/integrations/supabase/client');
+
+describe('PartnerService', () => {
+  const mockSupabase = vi.mocked(supabase);
+  let repository: IPartnerRepository;
+  let service: PartnerService;
+
+  beforeEach(() => {
+    repository = {
+      getAllPartners: vi.fn(),
+      getPartnerById: vi.fn(),
+      createPartner: vi.fn(),
+      updatePartner: vi.fn(),
+      deletePartner: vi.fn(),
+      updatePartnerOrder: vi.fn(),
+      getMaxDisplayOrder: vi.fn().mockResolvedValue(1)
+    } as unknown as IPartnerRepository;
+    service = new PartnerService(repository);
+    vi.clearAllMocks();
+  });
+
+  it('uploadPartnerLogo should upload file and return url', async () => {
+    const storageMock = {
+      upload: vi.fn().mockResolvedValue({ error: null }),
+      getPublicUrl: vi.fn().mockReturnValue({ data: { publicUrl: 'url' } })
+    };
+    mockSupabase.storage = {
+      from: vi.fn(() => storageMock as any)
+    } as any;
+
+    const file = new File(['test'], 'logo.png');
+    const result = await service.uploadPartnerLogo(file);
+
+    expect(storageMock.upload).toHaveBeenCalled();
+    expect(result).toBe('url');
+  });
+
+  it('getNextDisplayOrder should increment max order', async () => {
+    (repository.getMaxDisplayOrder as any).mockResolvedValue(5);
+    const result = await service.getNextDisplayOrder();
+    expect(result).toBe(6);
+  });
+
+  it('createPartner should delegate to repository', async () => {
+    (repository.createPartner as any).mockResolvedValue({});
+    await service.createPartner({ partner_name: 'test', logo_url: 'x' });
+    expect(repository.createPartner).toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/StatisticsService.test.ts
+++ b/src/services/__tests__/StatisticsService.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SupabaseStatisticsService } from '@/services/StatisticsService';
+import { supabase } from '@/integrations/supabase/client';
+
+vi.mock('@/integrations/supabase/client');
+
+describe('SupabaseStatisticsService', () => {
+  const mockSupabase = vi.mocked(supabase);
+  let service: SupabaseStatisticsService;
+
+  beforeEach(() => {
+    service = new SupabaseStatisticsService();
+    vi.clearAllMocks();
+  });
+
+  it('should fetch admin stats', async () => {
+    mockSupabase.from.mockImplementation(() => ({
+      select: vi.fn().mockResolvedValue({ count: 1, error: null })
+    }) as any);
+
+    const result = await service.getAdminStats();
+
+    expect(result).toEqual({ reviews: 1, partners: 1, contacts: 1, content: 1 });
+    expect(mockSupabase.from).toHaveBeenCalledTimes(4);
+  });
+
+  it('should throw error when query fails', async () => {
+    mockSupabase.from.mockImplementationOnce(() => ({
+      select: vi.fn().mockResolvedValue({ count: null, error: new Error('fail') })
+    }) as any);
+
+    await expect(service.getAdminStats()).rejects.toThrow('fail');
+  });
+});


### PR DESCRIPTION
## Summary
- add `StatisticsService` and `PartnerService`
- expose new services via `ServiceProvider`
- extend `IPartnerRepository` with `getMaxDisplayOrder`
- update dashboard and admin forms to use services/repositories instead of Supabase client
- create unit tests for the new services

## Testing
- `npx -y vitest run` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6862ce5d42848321b3718df40145dc82