### PR TITLE
Configure Supabase client via env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_KEY=your-publishable-key

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ cd <YOUR_PROJECT_NAME>
 # Step 3: Install the necessary dependencies.
 npm i
 
-# Step 4: Start the development server with auto-reloading and an instant preview.
+# Step 4: Copy the example environment file and update the values
+cp .env.example .env
+vi .env
+
+# Step 5: Start the development server with auto-reloading and an instant preview.
 npm run dev
 ```
 
@@ -49,6 +53,15 @@ npm run dev
 - Select the "Codespaces" tab.
 - Click on "New codespace" to launch a new Codespace environment.
 - Edit files directly within the Codespace and commit and push your changes once you're done.
+
+## Environment variables
+
+Create a `.env` file based on the provided `.env.example` and set your Supabase project credentials:
+
+```ini
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_KEY=<your-anon-key>
+```
 
 ## What technologies are used for this project?
 

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://khrnmlvyxmehqtbsdzvt.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtocm5tbHZ5eG1laHF0YnNkenZ0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA2MjMzNTUsImV4cCI6MjA2NjE5OTM1NX0._qo7b-AechC9YnUZN3UlMrDzfbKaDGRlWFTLDX42uOw";
+const SUPABASE_URL = (import.meta.env.VITE_SUPABASE_URL || process.env.VITE_SUPABASE_URL) as string;
+const SUPABASE_PUBLISHABLE_KEY = (import.meta.env.VITE_SUPABASE_KEY || process.env.VITE_SUPABASE_KEY) as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,52 +1,55 @@
-
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [
-    react(),
-    mode === 'development' &&
-    componentTagger(),
-  ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd());
+  process.env = { ...process.env, ...env };
+
+  return {
+    server: {
+      host: "::",
+      port: 8080,
     },
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./src/test/setup.ts'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-      exclude: [
-        'node_modules/',
-        'src/test/',
-        '**/*.d.ts',
-        '**/*.config.*',
-        '**/coverage/**',
-        'src/integrations/',
-        'src/main.tsx',
-        '**/*.stories.*',
-        '**/*.test.*',
-        '**/*.spec.*'
-      ],
-      thresholds: {
-        global: {
-          branches: 70,
-          functions: 70,
-          lines: 70,
-          statements: 70
+    plugins: [
+      react(),
+      mode === 'development' && componentTagger(),
+    ].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: ['./src/test/setup.ts'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'json', 'html'],
+        exclude: [
+          'node_modules/',
+          'src/test/',
+          '**/*.d.ts',
+          '**/*.config.*',
+          '**/coverage/**',
+          'src/integrations/',
+          'src/main.tsx',
+          '**/*.stories.*',
+          '**/*.test.*',
+          '**/*.spec.*'
+        ],
+        thresholds: {
+          global: {
+            branches: 70,
+            functions: 70,
+            lines: 70,
+            statements: 70
+          }
         }
       }
     }
-  },
-}));
+  };
+});


### PR DESCRIPTION
## Summary
- replace hardcoded Supabase URL/key with environment variables
- load env variables in `vite.config.ts`
- add `.env.example`
- document new env setup in README

## Testing
- `npm run lint` *(fails: requires type info for @typescript-eslint/prefer-nullish-coalescing)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6862dba9c1a08321b9c753ac54218420