### PR TITLE
Add form field helpers and refactor forms

### DIFF
--- a/src/components/Admin/ContactInfoForm.tsx
+++ b/src/components/Admin/ContactInfoForm.tsx
@@ -6,6 +6,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useStandardToast } from '@/hooks/useStandardToast';
+import { useFormFields } from '@/hooks/useFormFields';
 
 interface ContactInfo {
   id: string;
@@ -23,7 +24,11 @@ interface ContactInfoFormProps {
 }
 
 const ContactInfoForm = ({ contact, onSuccess, onCancel }: ContactInfoFormProps) => {
-  const [formData, setFormData] = useState({
+  const {
+    fields: formData,
+    setField,
+    setFields,
+  } = useFormFields({
     type: '',
     value: '',
     label: '',
@@ -45,13 +50,13 @@ const ContactInfoForm = ({ contact, onSuccess, onCancel }: ContactInfoFormProps)
 
   useEffect(() => {
     if (contact) {
-      setFormData({
+      setFields({
         type: contact.type,
         value: contact.value,
         label: contact.label || '',
       });
     }
-  }, [contact]);
+  }, [contact, setFields]);
 
   const { contactRepository } = useRepositories();
 
@@ -95,7 +100,7 @@ const ContactInfoForm = ({ contact, onSuccess, onCancel }: ContactInfoFormProps)
     <form onSubmit={handleSubmit} className="max-w-2xl space-y-6">
       <div>
         <Label htmlFor="type">Type de contact *</Label>
-        <Select value={formData.type} onValueChange={(value) => setFormData({ ...formData, type: value })}>
+        <Select value={formData.type} onValueChange={(value) => setField('type', value)}>
           <SelectTrigger>
             <SelectValue placeholder="Sélectionnez un type" />
           </SelectTrigger>
@@ -114,7 +119,7 @@ const ContactInfoForm = ({ contact, onSuccess, onCancel }: ContactInfoFormProps)
         <Input
           id="label"
           value={formData.label}
-          onChange={(e) => setFormData({ ...formData, label: e.target.value })}
+          onChange={(e) => setField('label', e.target.value)}
           placeholder="ex: Téléphone principal, Email support..."
         />
         <p className="text-xs text-gray-500 mt-1">
@@ -128,7 +133,7 @@ const ContactInfoForm = ({ contact, onSuccess, onCancel }: ContactInfoFormProps)
           <Textarea
             id="value"
             value={formData.value}
-            onChange={(e) => setFormData({ ...formData, value: e.target.value })}
+            onChange={(e) => setField('value', e.target.value)}
             placeholder={
               formData.type === 'hours' 
                 ? "Lundi - Vendredi: 9h00 - 19h00\nSamedi: Sur rendez-vous"
@@ -143,7 +148,7 @@ const ContactInfoForm = ({ contact, onSuccess, onCancel }: ContactInfoFormProps)
           <Input
             id="value"
             value={formData.value}
-            onChange={(e) => setFormData({ ...formData, value: e.target.value })}
+            onChange={(e) => setField('value', e.target.value)}
             placeholder={
               formData.type === 'phone' || formData.type === 'whatsapp'
                 ? "+33 6 00 00 00 00"

--- a/src/components/Admin/PartnerForm.tsx
+++ b/src/components/Admin/PartnerForm.tsx
@@ -8,6 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent } from '@/components/ui/card';
 import { useToast } from '@/hooks/use-toast';
 import { Upload, X, ExternalLink } from 'lucide-react';
+import { useFormFields } from '@/hooks/useFormFields';
 
 interface Partner {
   id: string;
@@ -26,7 +27,11 @@ interface PartnerFormProps {
 }
 
 const PartnerForm = ({ partner, onSuccess, onCancel }: PartnerFormProps) => {
-  const [formData, setFormData] = useState({
+  const {
+    fields: formData,
+    setField,
+    setFields,
+  } = useFormFields({
     partner_name: '',
     website_url: '',
   });
@@ -40,13 +45,13 @@ const PartnerForm = ({ partner, onSuccess, onCancel }: PartnerFormProps) => {
 
   useEffect(() => {
     if (partner) {
-      setFormData({
+      setFields({
         partner_name: partner.partner_name,
         website_url: partner.website_url || '',
       });
       setLogoPreview(partner.logo_url);
     }
-  }, [partner]);
+  }, [partner, setFields]);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -172,7 +177,7 @@ const PartnerForm = ({ partner, onSuccess, onCancel }: PartnerFormProps) => {
         <Input
           id="partner_name"
           value={formData.partner_name}
-          onChange={(e) => setFormData({ ...formData, partner_name: e.target.value })}
+          onChange={(e) => setField('partner_name', e.target.value)}
           required
           placeholder="Nom de l'entreprise partenaire"
         />
@@ -184,7 +189,7 @@ const PartnerForm = ({ partner, onSuccess, onCancel }: PartnerFormProps) => {
           id="website_url"
           type="url"
           value={formData.website_url}
-          onChange={(e) => setFormData({ ...formData, website_url: e.target.value })}
+          onChange={(e) => setField('website_url', e.target.value)}
           placeholder="https://www.exemple.com"
         />
         {formData.website_url && (

--- a/src/components/Admin/__tests__/ContactInfoForm.test.tsx
+++ b/src/components/Admin/__tests__/ContactInfoForm.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@/test/utils/test-utils';
+import ContactInfoForm from '../ContactInfoForm';
+
+describe('ContactInfoForm', () => {
+  it('updates label and value fields', () => {
+    render(<ContactInfoForm onSuccess={vi.fn()} onCancel={vi.fn()} />);
+    const labelInput = screen.getByLabelText('Libellé');
+    fireEvent.change(labelInput, { target: { value: 'Principal' } });
+    expect(labelInput).toHaveValue('Principal');
+
+    const valueInput = screen.getByLabelText('Valeur *');
+    fireEvent.change(valueInput, { target: { value: 'test value' } });
+    expect(valueInput).toHaveValue('test value');
+  });
+});

--- a/src/components/Admin/__tests__/PartnerForm.test.tsx
+++ b/src/components/Admin/__tests__/PartnerForm.test.tsx
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@/test/utils/test-utils';
+import PartnerForm from '../PartnerForm';
+
+describe('PartnerForm', () => {
+  it('updates partner_name field correctly', () => {
+    render(<PartnerForm onSuccess={vi.fn()} onCancel={vi.fn()} />);
+    const input = screen.getByLabelText('Nom du partenaire *');
+    fireEvent.change(input, { target: { value: 'Test Partner' } });
+    expect(input).toHaveValue('Test Partner');
+  });
+});

--- a/src/hooks/__tests__/useFormFields.test.ts
+++ b/src/hooks/__tests__/useFormFields.test.ts
@@ -1,0 +1,16 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useFormFields } from '@/hooks/useFormFields';
+
+describe('useFormFields', () => {
+  it('should update field with setField and retrieve with getField', () => {
+    const { result } = renderHook(() => useFormFields({ name: '', email: '' }));
+
+    act(() => {
+      result.current.setField('name', 'John');
+    });
+
+    expect(result.current.getField('name')).toBe('John');
+    expect(result.current.fields.name).toBe('John');
+  });
+});

--- a/src/hooks/useFormFields.ts
+++ b/src/hooks/useFormFields.ts
@@ -1,0 +1,18 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Manage form fields with dedicated getters and setters.
+ */
+export function useFormFields<T extends Record<string, any>>(initialState: T) {
+  const [fields, setFields] = useState<T>(initialState);
+
+  const getField = useCallback(<K extends keyof T>(key: K): T[K] => fields[key], [fields]);
+
+  const setField = useCallback(<K extends keyof T>(key: K, value: T[K]) => {
+    setFields(prev => ({ ...prev, [key]: value }));
+  }, []);
+
+  return { fields, setFields, getField, setField };
+}
+
+export type UseFormFieldsReturn<T extends Record<string, any>> = ReturnType<typeof useFormFields<T>>;


### PR DESCRIPTION
## Summary
- implement `useFormFields` hook exposing typed getters and setters
- refactor `PartnerForm` and `ContactInfoForm` to use the new hook
- add tests for the hook and updated forms

## Testing
- `npx -y vitest run` *(fails: cannot load vite due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862df11eee483218a448e66b5429905